### PR TITLE
fix: check supported channels of AU Plugin

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AU_Shared.h
+++ b/modules/juce_audio_processors/format_types/juce_AU_Shared.h
@@ -359,7 +359,7 @@ struct AudioUnitHelpers
         }
 
         auto layout = processor.getBusesLayout();
-        auto maxNumChanToCheckFor = 9;
+        auto maxNumChanToCheckFor = 24;
 
         auto defaultInputs  = processor.getChannelCountOfBus (true,  0);
         auto defaultOutputs = processor.getChannelCountOfBus (false, 0);


### PR DESCRIPTION
AU Plugin のチャンネル情報を AU ホストに通知する際にチェックするチャンネル数を 9 ch から 24 ch に増やした。（これによって、 Logic Pro の dolby atmos トラックでプラグインが正しく使用できるようになる。）